### PR TITLE
Improvements and fixes

### DIFF
--- a/buffer.tres
+++ b/buffer.tres
@@ -33,7 +33,6 @@ void fragment() {
 
 }
 "
-graph_offset = Vector2(78, 98)
 mode = 1
 flags/light_only = false
 nodes/fragment/0/position = Vector2(780, 160)

--- a/icon.svg.import
+++ b/icon.svg.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/icon.svg-218a8f2b3041327d8a5756f3a245f83b.cte
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/main.tres
+++ b/main.tres
@@ -1,4 +1,4 @@
-[gd_resource type="VisualShader" load_steps=26 format=3 uid="uid://c7d7kiigmb7le"]
+[gd_resource type="VisualShader" load_steps=29 format=3 uid="uid://c7d7kiigmb7le"]
 
 [sub_resource type="VisualShaderNodeColorParameter" id="VisualShaderNodeColorParameter_jw5th"]
 parameter_name = "shallow_water"
@@ -10,7 +10,7 @@ default_input_values = [0, Vector3(0, 0, 0), 1, Vector3(1, 1, 1), 2, Vector3(0.5
 op_type = 3
 
 [sub_resource type="VisualShaderNodeExpression" id="VisualShaderNodeExpression_go6ns"]
-size = Vector2(501.944, 279.904)
+size = Vector2(500, 300)
 expression = "vec3 duv = vec3(4.0 / 514.0, 4.0 / 514.0, 0);
 float v1 = texture(sim, UV - duv.xz).y;
 float v2 = texture(sim, UV + duv.xz).y;
@@ -46,6 +46,16 @@ constant = 0.8
 parameter_name = "simulation"
 
 [sub_resource type="VisualShaderNodeLinearSceneDepth" id="VisualShaderNodeLinearSceneDepth_27hr3"]
+
+[sub_resource type="VisualShaderNodeTexture" id="VisualShaderNodeTexture_0ij0k"]
+source = 5
+
+[sub_resource type="VisualShaderNodeMultiplyAdd" id="VisualShaderNodeMultiplyAdd_86m1o"]
+default_input_values = [0, Vector3(0, 0, 0), 1, Vector3(0.5, 0.5, 0.5), 2, Vector3(0.5, 0.5, 0.5)]
+op_type = 2
+
+[sub_resource type="VisualShaderNodeVectorCompose" id="VisualShaderNodeVectorCompose_ef8h3"]
+default_input_values = [0, 0.5, 1, 0.5, 2, 0.5]
 
 [sub_resource type="VisualShaderNodeExpression" id="VisualShaderNodeExpression_bxgl8"]
 size = Vector2(512.6, 290.56)
@@ -236,15 +246,26 @@ void fragment() {
 	float n_out8p0 = 1.0 - n_out6p0;
 
 
+// VectorCompose:24
+	float n_in24p0 = 0.50000;
+	float n_in24p1 = 0.50000;
+	float n_in24p2 = 0.50000;
+	vec3 n_out24p0 = vec3(n_in24p0, n_in24p1, n_in24p2);
+
+
+// MultiplyAdd:23
+	vec3 n_out23p0 = fma(n_out12p0, n_out24p0, n_out24p0);
+
+
 // Output:0
 	ALBEDO = n_out18p0;
 	ALPHA = n_out8p0;
-	NORMAL = n_out12p0;
+	NORMAL_MAP = n_out23p0;
 
 
 }
 "
-graph_offset = Vector2(-1091.11, -508.067)
+graph_offset = Vector2(-497.608, -324.706)
 nodes/vertex/0/position = Vector2(660, 40)
 nodes/vertex/2/node = SubResource("VisualShaderNodeInput_olx2s")
 nodes/vertex/2/position = Vector2(-820, 100)
@@ -286,7 +307,7 @@ nodes/fragment/11/node = SubResource("VisualShaderNodeMix_mhput")
 nodes/fragment/11/position = Vector2(2.72259, 77.1215)
 nodes/fragment/12/node = SubResource("VisualShaderNodeExpression_go6ns")
 nodes/fragment/12/position = Vector2(-380, -460)
-nodes/fragment/12/size = Vector2(501.944, 279.904)
+nodes/fragment/12/size = Vector2(500, 300)
 nodes/fragment/12/input_ports = "0,8,sim;"
 nodes/fragment/12/output_ports = "0,4,normal;"
 nodes/fragment/12/expression = "vec3 duv = vec3(4.0 / 514.0, 4.0 / 514.0, 0);
@@ -314,4 +335,10 @@ nodes/fragment/20/node = SubResource("VisualShaderNodeTexture2DParameter_75g8n")
 nodes/fragment/20/position = Vector2(-780, -440)
 nodes/fragment/21/node = SubResource("VisualShaderNodeLinearSceneDepth_27hr3")
 nodes/fragment/21/position = Vector2(-640, 580)
-nodes/fragment/connections = PackedInt32Array(7, 0, 6, 0, 6, 0, 8, 0, 9, 0, 11, 0, 10, 0, 11, 1, 12, 0, 0, 8, 13, 0, 14, 0, 12, 0, 14, 1, 14, 0, 15, 0, 16, 0, 15, 1, 15, 0, 17, 0, 17, 0, 18, 0, 11, 0, 18, 1, 19, 0, 18, 2, 20, 0, 12, 0, 21, 0, 6, 1, 6, 0, 11, 2, 18, 0, 0, 0, 8, 0, 0, 1)
+nodes/fragment/22/node = SubResource("VisualShaderNodeTexture_0ij0k")
+nodes/fragment/22/position = Vector2(120, -180)
+nodes/fragment/23/node = SubResource("VisualShaderNodeMultiplyAdd_86m1o")
+nodes/fragment/23/position = Vector2(660, 320)
+nodes/fragment/24/node = SubResource("VisualShaderNodeVectorCompose_ef8h3")
+nodes/fragment/24/position = Vector2(420, 500)
+nodes/fragment/connections = PackedInt32Array(7, 0, 6, 0, 6, 0, 8, 0, 9, 0, 11, 0, 10, 0, 11, 1, 13, 0, 14, 0, 12, 0, 14, 1, 14, 0, 15, 0, 16, 0, 15, 1, 15, 0, 17, 0, 17, 0, 18, 0, 11, 0, 18, 1, 19, 0, 18, 2, 20, 0, 12, 0, 21, 0, 6, 1, 6, 0, 11, 2, 8, 0, 0, 1, 20, 0, 22, 2, 18, 0, 0, 0, 12, 0, 23, 0, 23, 0, 0, 9, 24, 0, 23, 1, 24, 0, 23, 2)

--- a/main.tscn
+++ b/main.tscn
@@ -108,10 +108,10 @@ viewport_path = NodePath("Simulation")
 resource_local_to_scene = true
 render_priority = 0
 shader = ExtResource("2_7fen6")
-shader_parameter/amplitude = 0.5
+shader_parameter/amplitude = 0.05
 shader_parameter/refraction_strength = 0.1
-shader_parameter/deep_water = Color(0, 0.168627, 0.643137, 0.945098)
-shader_parameter/shallow_water = Color(0, 0.34902, 0.34902, 0.67451)
+shader_parameter/deep_water = Color(0, 0, 1, 1)
+shader_parameter/shallow_water = Color(0, 1, 1, 1)
 shader_parameter/murkiness = 0.407
 shader_parameter/simulation2 = SubResource("ViewportTexture_ceg2r")
 shader_parameter/simulation = SubResource("ViewportTexture_m1c3a")
@@ -133,6 +133,7 @@ transform = Transform3D(-0.866023, -0.433016, 0.250001, 0, 0.499998, 0.866027, -
 shadow_enabled = true
 
 [node name="SimulationBuffer" type="SubViewport" parent="."]
+use_hdr_2d = true
 size = Vector2i(514, 512)
 render_target_clear_mode = 2
 render_target_update_mode = 4
@@ -147,6 +148,7 @@ grow_vertical = 2
 color = Color(0, 0, 0, 1)
 
 [node name="Simulation" type="SubViewport" parent="."]
+use_hdr_2d = true
 size = Vector2i(514, 512)
 render_target_clear_mode = 2
 render_target_update_mode = 4
@@ -186,10 +188,10 @@ layers = 524288
 mesh = SubResource("SphereMesh_hyi7f")
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="Ball"]
-autoplay = "dip"
 libraries = {
 "": SubResource("AnimationLibrary_oo1wg")
 }
+autoplay = "dip"
 
 [node name="CSGBox3D" type="CSGBox3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -1.6945, 0)

--- a/project.godot
+++ b/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="Water sim YT"
 run/main_scene="res://main.tscn"
-config/features=PackedStringArray("4.1", "Forward Plus")
+config/features=PackedStringArray("4.3", "Forward Plus")
 run/max_fps=60
 config/icon="res://icon.svg"
 

--- a/simulation.gdshader
+++ b/simulation.gdshader
@@ -19,18 +19,18 @@ void fragment() {
 		texture(sim_tex, UV + duv.zy).r +
 		texture(sim_tex, UV - duv.xz).r +
 		texture(sim_tex, UV + duv.xz).r - 4.0 * c.r)) * attenuation;
-		
+
 	vec2 col_uv = vec2(UV.x, 1.0 - UV.y);
 	float col = texture(col_tex, col_uv).r;
 	float prevCol = texture(sim_tex, UV).b;
-	
-	if (col > 0.0 && prevCol == 0.0) {
+
+	if (col > 0.0 && (prevCol < 0.001 && prevCol > -0.001)) {
 		p += col * 0.5;
 	}
-	
-	if (prevCol > 0.0 && col == 0.0) {
+
+	if (prevCol > 0.0 && (col < 0.001 && col > -0.001)) {
 		p -= prevCol * 0.5;
 	}
-		
+
 	COLOR = vec4(p, c.r, col, 1);
 }


### PR DESCRIPTION
Followed the youtube tutorial, but had a few problems. Took care of them in this fork. 
1- fixed 0 comparison in simulation shader
Replaced comparison to 0, with a range. No longer throws warnings and works the same as before. 
2- Fixed normals
Water surface darkens when viewed from shallow angles in the positive Z direction. Fixed by adjusting normal vector and sending it to the normal map output. 
3- Endless wave fix
Noticed waves would leave behind endless noise that wouldn't fade away. Fixed by setting simulation and buffer to use 2D HDR for more precision. Also lowered attenuation in water shader to match original result more closely.